### PR TITLE
Export image and QRcode print methods

### DIFF
--- a/android/src/main/java/com/pinmi/react/printer/RNBLEPrinterModule.java
+++ b/android/src/main/java/com/pinmi/react/printer/RNBLEPrinterModule.java
@@ -71,12 +71,14 @@ public class RNBLEPrinterModule extends ReactContextBaseJavaModule implements RN
         adapter.printRawData(base64Data, errorCallback);
     }
 
+    @ReactMethod
     @Override
     public void printImageData(String imageUrl, Callback errorCallback) {
         Log.v("imageUrl", imageUrl);
         adapter.printImageData(imageUrl, errorCallback);
     }
 
+    @ReactMethod
     @Override
     public void printQrCode(String imageUrl, Callback errorCallback) {
         byte[] decodedString = Base64.decode(imageUrl, Base64.DEFAULT);


### PR DESCRIPTION
Defines the `printImage` and `printQrCode` methods as ReactMethods so they are made available on the NativeModules in Android.
#6