### PR TITLE
Fixed getDeviceList on iOS not waiting queue to finished

### DIFF
--- a/ios/RNNetPrinter.m
+++ b/ios/RNNetPrinter.m
@@ -82,13 +82,11 @@ RCT_EXPORT_METHOD(getDeviceList:(RCTResponseSenderBlock)successCallback
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handlePrinterConnectedNotification:) name:PrinterConnectedNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleBLEPrinterConnectedNotification:) name:@"BLEPrinterConnected" object:nil];
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        [self scan];
+        [self scan:successCallback];
     });
-
-    successCallback(@[_printerArray]);
 }
 
-- (void) scan {
+- (void) scan: (RCTResponseSenderBlock)successCallback {
     @try {
         PrivateIP *privateIP = [[PrivateIP alloc]init];
         NSString *localIP = [privateIP getIPAddress];
@@ -112,6 +110,8 @@ RCT_EXPORT_METHOD(getDeviceList:(RCTResponseSenderBlock)successCallback
         _printerArray = (NSMutableArray *)arrayWithoutDuplicates;
 
         [self sendEventWithName:EVENT_SCANNER_RESOLVED body:_printerArray];
+
+        successCallback(@[_printerArray]);
     } @catch (NSException *exception) {
         NSLog(@"No connection");
     }


### PR DESCRIPTION
Hi @thiendangit , first of all, let me express my gratitude on your great works on adding image and QR support!

FYI I just noticed a bug on iOS, calling getDeviceList will return the result early (empty array), without waiting for the scanning process to completed.