### PR TITLE
Fixed android usb connection app crash

### DIFF
--- a/android/src/main/java/com/pinmi/react/printer/adapter/USBPrinterAdapter.java
+++ b/android/src/main/java/com/pinmi/react/printer/adapter/USBPrinterAdapter.java
@@ -107,7 +107,7 @@ public class USBPrinterAdapter implements PrinterAdapter {
     public void init(ReactApplicationContext reactContext, Callback successCallback, Callback errorCallback) {
         this.mContext = reactContext;
         this.mUSBManager = (UsbManager) this.mContext.getSystemService(Context.USB_SERVICE);
-        this.mPermissionIndent = PendingIntent.getBroadcast(mContext, 0, new Intent(ACTION_USB_PERMISSION), 0);
+        this.mPermissionIndent = PendingIntent.getBroadcast(mContext, 0, new Intent(ACTION_USB_PERMISSION), PendingIntent.FLAG_MUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);
         IntentFilter filter = new IntentFilter(ACTION_USB_PERMISSION);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
         filter.addAction(UsbManager.ACTION_USB_ACCESSORY_ATTACHED);


### PR DESCRIPTION
Follow-up on [issue70](https://github.com/thiendangit/react-native-thermal-receipt-printer-image-qr/issues/70#issue-1338642435)

**This PR contains:**
Flag is added for the Pending Intent.

> Targeting S+ (version 10000 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent