### PR TITLE
Refactor closeConn method in printer modules to handle null adapter

### DIFF
--- a/android/src/main/java/com/pinmi/react/printer/RNBLEPrinterModule.java
+++ b/android/src/main/java/com/pinmi/react/printer/RNBLEPrinterModule.java
@@ -45,7 +45,10 @@ public class RNBLEPrinterModule extends ReactContextBaseJavaModule implements RN
     @ReactMethod
     @Override
     public void closeConn() {
-        adapter.closeConnectionIfExists();
+        if (this.adapter == null) {
+            this.adapter = BLEPrinterAdapter.getInstance();
+        }
+        this.adapter.closeConnectionIfExists();
     }
 
     @ReactMethod

--- a/android/src/main/java/com/pinmi/react/printer/RNNetPrinterModule.java
+++ b/android/src/main/java/com/pinmi/react/printer/RNNetPrinterModule.java
@@ -37,7 +37,9 @@ public class RNNetPrinterModule extends ReactContextBaseJavaModule implements RN
     @ReactMethod
     @Override
     public void closeConn() {
-        this.adapter = NetPrinterAdapter.getInstance();
+        if (this.adapter == null) {
+            this.adapter = NetPrinterAdapter.getInstance();
+        }
         this.adapter.closeConnectionIfExists();
     }
 

--- a/android/src/main/java/com/pinmi/react/printer/RNUSBPrinterModule.java
+++ b/android/src/main/java/com/pinmi/react/printer/RNUSBPrinterModule.java
@@ -42,7 +42,10 @@ public class RNUSBPrinterModule extends ReactContextBaseJavaModule implements RN
     @ReactMethod
     @Override
     public void closeConn()  {
-        adapter.closeConnectionIfExists();
+        if (this.adapter == null) {
+            this.adapter = USBPrinterAdapter.getInstance();
+        }
+        this.adapter.closeConnectionIfExists();
     }
 
     @ReactMethod


### PR DESCRIPTION
The closeConn method in the RNBLEPrinterModule, RNNetPrinterModule, and RNUSBPrinterModule has been refactored to handle the case where the adapter is null. If the adapter is null, it is initialized before closing the connection. This change ensures that the closeConn method works correctly even when the adapter is not yet instantiated.